### PR TITLE
Set LoopVectorization lower bound to 0.8.7, as this requires at least…

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,7 +8,7 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 LoopVectorization = "bdcacae8-1622-11e9-2a5c-532679323890"
 
 [compat]
-LoopVectorization = "0.7,0.8"
+LoopVectorization = "0.8.7"
 julia = "1.1"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,7 @@ LoopVectorization = "bdcacae8-1622-11e9-2a5c-532679323890"
 VectorizationBase = "3d5dd08c-fd9d-11e8-17fa-ed2836048c2f"
 
 [compat]
-VectorizationBase = "0.12.9"
+VectorizationBase = "0.12.13"
 LoopVectorization = "0.8"
 julia = "1.1"
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,14 +1,16 @@
 name = "RecursiveFactorization"
 uuid = "f2c3362d-daeb-58d1-803e-2bc74f2840b4"
 authors = ["Yingbo Ma <mayingbo5@gmail.com>"]
-version = "0.1.2"
+version = "0.1.3"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 LoopVectorization = "bdcacae8-1622-11e9-2a5c-532679323890"
+VectorizationBase = "3d5dd08c-fd9d-11e8-17fa-ed2836048c2f"
 
 [compat]
-LoopVectorization = "0.8.7"
+VectorizationBase = "0.12.9"
+LoopVectorization = "0.8"
 julia = "1.1"
 
 [extras]


### PR DESCRIPTION
Because this requires at least VectorizationBase 0.12.11, which includes
1. a workaround for a bug in Ice Lake OSX systems preventing it from supporting AVX512 even when the CPU does, and
2. a workaround for systems with multiple loaded LLVM libraries by falling back on the original CpuId.jl behavior.

Or should I instead add VectorizationBase as a dependency directly?