### PR TITLE
Check if iterables are empty

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RecursiveFactorization"
 uuid = "f2c3362d-daeb-58d1-803e-2bc74f2840b4"
 authors = ["Yingbo Ma <mayingbo5@gmail.com>"]
-version = "0.1.3"
+version = "0.1.4"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/lu.jl
+++ b/src/lu.jl
@@ -181,12 +181,13 @@ function _generic_lufact!(A, ::Val{Pivot}, ipiv, info) where Pivot
                 end
                 # Scale first column
                 Akkinv = inv(A[k,k])
-                @avx for i = k+1:m
+                @avx check_empty=true for i = k+1:m
                     A[i,k] *= Akkinv
                 end
             elseif info == 0
                 info = k
             end
+            k == minmn && break 
             # Update the rest
             @avx for j = k+1:n
                 for i = k+1:m


### PR DESCRIPTION
LoopVectorization currently doesn't check if iterables are empty by default.
That may change, but for now, we have to either use `@avx check_empty=true for ...` or add a check ourselves if it is possible that an iterable will in fact be empty.

I added checks in two locations in this PR.
The check on line 184 is actually unnecessary, so perhaps I should set it to `false`.
It is unnecessary because that loop will be vectorized and unrolled. Whenever a loop is unrolled by a factor greater than 1x (this includes vectorization), it needs to emit checks on iterable length before the loop anyway, since loops with length less than the unrolling factor are allowed.

However, @ChrisRackauckas was seeing segfaults originating from the second block of code, meaning it has been confirmed problematic. While the `i` loop will almost certainly be vectorized, following a recent change in LoopVectorization (https://github.com/chriselrod/LoopVectorization.jl/commit/e0f5dcf412affc339570e8b7cf63a326d0e3480c), 
```julia
using LoopVectorization
m, n, k = 2, 2, 1
A = rand(m, n);
ls = LoopVectorization.@avx_debug for j = k+1:n
    for i = k+1:m
        A[i,j] -= A[i,k]*A[k,j]
    end
end;
LoopVectorization.choose_order(ls)
# ([:j, :i], :j, Symbol("##undefined##"), :i, 1, -1)
```
it is now suddenly far less aggressive about unrolling certain kinds of loops.

Before the linked commit, it would have unrolled both loops, meaning it also would have checked both loops.
Now that it no longer unrolls the `j` loop, it no longer checks it by default.

Given that this library is probably the most important application of LoopVectorization to date, it's probably worth benchmarking whether this change boosted `_generic_lu!`'s performance, and to make decisions on tuning LoopVectorization's performance on behalf of this library.