### PR TITLE
VectorizationBase no longer using global constants to define parameters

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,9 +9,9 @@ LoopVectorization = "bdcacae8-1622-11e9-2a5c-532679323890"
 VectorizationBase = "3d5dd08c-fd9d-11e8-17fa-ed2836048c2f"
 
 [compat]
-LoopVectorization = "0.8,0.9"
-VectorizationBase = "0.12.13,0.13, 0.14, 0.15, 0.16"
-julia = "1.1"
+LoopVectorization = "0.10"
+VectorizationBase = "0.16"
+julia = "1.5"
 
 [extras]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/src/lu.jl
+++ b/src/lu.jl
@@ -23,9 +23,9 @@ function pick_threshold()
     blasvendor = BLAS.vendor()
     RECURSION_THRESHOLD[] >= 0 && return RECURSION_THRESHOLD[]
     if blasvendor === :openblas || blasvendor === :openblas64
-        LoopVectorization.VectorizationBase.AVX512F ? 110 : 72
+        LoopVectorization.register_size() == 64 ? 110 : 72
     else
-        LoopVectorization.VectorizationBase.AVX512F ? 48 : 72
+        LoopVectorization.register_size() == 64 ? 48 : 72
     end
 end
 


### PR DESCRIPTION
It was causing problems when built into a sysimage and then distributed.
Of course, if someone calls `LoopVectorization.VectorizationBase,register_size()` at some point in the compilation process, we still have a problem. But hopefully they don't.