### PR TITLE
Import mul! from LinearAlgebra in butterflylu.jl

### DIFF
--- a/src/butterflylu.jl
+++ b/src/butterflylu.jl
@@ -1,5 +1,5 @@
 using VectorizedRNG
-using LinearAlgebra: Diagonal, I
+using LinearAlgebra: Diagonal, I, mul!
 using LoopVectorization
 using RecursiveFactorization
 using SparseBandedMatrices


### PR DESCRIPTION
⚠️ Draft — please ignore until reviewed by @ChrisRackauckas.

## What changed and why

`src/butterflylu.jl` calls `mul!` in `🦋solve!` and `materializeUV` but only imports `Diagonal` and `I` from LinearAlgebra, so any use of the butterfly path (`🦋workspace` / `🦋solve!`) throws `UndefVarError: mul! not defined in RecursiveFactorization` — including the `🦋` testset at `test/runtests.jl:80` on current master. This adds `mul!` to the existing `using LinearAlgebra:` line. Introduced by https://github.com/JuliaLinearAlgebra/RecursiveFactorization.jl/commit/0e635a217efa4abbf4556379da3f4afa0da05dc9 ("refactor butterfly into new struct", PR #103), which dropped the file's plain `using LinearAlgebra` while keeping bare `mul!` calls; PR #104 later added two more bare `mul!` calls in `🦋solve!`.

## Verification (Julia 1.12.4)

Failing before (unmodified master, `bc3bb8a`):

```
$ julia -e 'using Pkg; Pkg.activate(mktempdir()); Pkg.develop(path="<clone>"); using RecursiveFactorization; A=rand(64,64); b=rand(64); RecursiveFactorization.🦋workspace(A,b)'
ERROR: UndefVarError: `mul!` not defined in `RecursiveFactorization`
Suggestion: check for spelling errors or missing imports.
Hint: a global variable of this name also exists in LinearAlgebra.
Stacktrace:
 [1] materializeUV(U::Matrix{Float64}, V::Matrix{Float64}, uv::Vector{Float64})
   @ RecursiveFactorization src/butterflylu.jl:176
 [2] RecursiveFactorization.🦋workspace(A::Matrix{Float64}, b::Vector{Float64}, ::Val{888})
   @ RecursiveFactorization src/butterflylu.jl:40
```

Passing after (same command plus `🦋solve!`, with this one-line fix):

```
workspace+solve OK
```

Full test suite (`Pkg.test("RecursiveFactorization")` on this branch):

```
Test Summary:         | Pass  Total     Time
Test LU factorization | 3120   3120  2m23.8s
Test Summary: | Pass  Total  Time
🦋            |   21     21  2.1s
     Testing RecursiveFactorization tests passed
```

Not verified: `lts` and `pre` CI lanes (ran locally on 1.12.4 only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
