### PR TITLE
Require TriangularSolve 0.2.2 for the native upper-triangular ldiv!

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RecursiveFactorization"
 uuid = "f2c3362d-daeb-58d1-803e-2bc74f2840b4"
 authors = ["Yingbo Ma <mayingbo5@gmail.com>"]
-version = "0.2.26"
+version = "0.2.27"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
@@ -20,7 +20,7 @@ Polyester = "0.3.2,0.4.1, 0.5, 0.6, 0.7"
 PrecompileTools = "1"
 SparseBandedMatrices = "1"
 StrideArraysCore = "0.5.5"
-TriangularSolve = "0.2"
+TriangularSolve = "0.2.2"
 VectorizedRNG = "0.2.25"
 julia = "1.10"
 


### PR DESCRIPTION
⚠️ **Draft — please ignore until reviewed by @ChrisRackauckas.**

🚧 **Blocked on TriangularSolve 0.2.2 being merged and registered** (native upper-triangular `ldiv!`, prepared at [ChrisRackauckas-Claude/TriangularSolve.jl `upper-ldiv`](https://github.com/JuliaSIMD/TriangularSolve.jl/compare/main...ChrisRackauckas-Claude:TriangularSolve.jl:upper-ldiv); spec in https://github.com/SciML/LinearSolve.jl/issues/1146). Until it is registered, CI here fails at `Pkg` resolution because the `0.2.2` lower bound does not exist yet.

## What changed and why

Compat-only: require `TriangularSolve = "0.2.2"` and bump this package to 0.2.27. TriangularSolve 0.2.2 adds `ldiv!(::UpperTriangular, ::AbstractMatrix)`, so the U leg of the pivotless (`NotIPIV`) LU `ldiv!` in `src/lu.jl` — which already calls `TriangularSolve.ldiv!` on both legs — now dispatches to a native SIMD kernel instead of silently falling through TriangularSolve's catch-all to BLAS `trsm`. No code change is needed here.

## Verification

Full test suite run locally (Julia 1.12.4, AMD EPYC 7502) with the TriangularSolve `upper-ldiv` branch `Pkg.develop`ed:

```
Test Summary:         | Pass  Total     Time
Test LU factorization | 3120   3120  2m28.0s
```

The `🦋` testset errors on this branch **and on unmodified master** with `UndefVarError: mul! not defined in RecursiveFactorization` — a pre-existing master breakage introduced by 0e635a2 (see the bisect + one-line fix in #111, which this PR depends on for green CI). It is unrelated to this compat change.

Solve-only kernel benchmark backing the change (Float64, nrhs=8, 1 BLAS thread, EPYC 7502/AVX2; `U`-leg comparison of `LinearAlgebra.ldiv!` (BLAS trsm, the old fallback) vs `TriangularSolve.ldiv!` 0.2.2 native):

```
  n     trsm        TS native
  64      4.09 us    1.78 us   (2.3x)
  128    12.36 us    6.27 us   (2.0x)
  256    49.18 us   22.04 us   (2.2x)
  500   154.79 us   79.64 us   (1.9x)
```

## What was not verified

- Julia lts/pre lanes (local run was 1.12.4; TriangularSolve itself was validated on 1.10.11 and 1.12.4).
- The 🦋 path (pre-existing failure, fixed separately in #111).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
