### PR TITLE
Pin the Invalidations workflow to Julia 1.11 (SnoopCompile #465 crashes on 1.12)

### DIFF
--- a/.github/workflows/Invalidations.yml
+++ b/.github/workflows/Invalidations.yml
@@ -18,7 +18,12 @@ jobs:
     steps:
     - uses: julia-actions/setup-julia@v1
       with:
-        version: '1'
+        # Pinned to 1.11: SnoopCompile's report_invalidations crashes on Julia
+        # 1.12 binding invalidations (JuliaDebug/SnoopCompile.jl#465), so on '1'
+        # this job has been red since Julia 1.12.0 (2025-10-08).  Revert to '1'
+        # once a fixed SnoopCompile v3.x is out (the action adds it fresh each
+        # run).
+        version: '1.11'
     - uses: actions/checkout@v4
     - uses: julia-actions/julia-buildpkg@v1
     - uses: julia-actions/julia-invalidations@v1


### PR DESCRIPTION
⚠️ Draft — please ignore until reviewed by @ChrisRackauckas.

Mechanical CI fix, shipped alone: the `Invalidations.yml` `evaluate` job has been red on **every** run since 2025-10-08 — not because invalidations regressed, but because the reporting tool crashes before producing any counts.

## Root cause (upstream, RF-independent)

`setup-julia` with `version: '1'` began resolving to Julia 1.12.0 on 2025-10-08 (release ~5 h before the first red run). On 1.12, invalidation trees can be rooted at a `Core.Binding` (binding partitions), and SnoopCompile's `report_invalidations` (`ext/SCPrettyTablesExt.jl:34-39`) still assumes `Method`, crashing with:

```
FieldError: type Core.Binding has no field `name`, available fields: `globalref`, `value`, `partitions`, `backedges`, `flags`
```

Upstream issue (open, exact match): https://github.com/JuliaDebug/SnoopCompile.jl/issues/465. A standalone SnoopCompile-only reproducer (no RF imports) was reduced and verified on a clean env during the investigation; the trigger is any ≥1 Binding-rooted tree, which essentially any real package load produces on 1.12.

- Last green master run (Julia 1.11 era): https://github.com/JuliaLinearAlgebra/RecursiveFactorization.jl/actions/runs/18264377614
- First red master run: https://github.com/JuliaLinearAlgebra/RecursiveFactorization.jl/actions/runs/18358150673
- Same crash on PR CI, e.g.: https://github.com/JuliaLinearAlgebra/RecursiveFactorization.jl/actions/runs/31273560099/job/93143409058

## The fix

Pin the job's Julia to `'1.11'` with a comment pointing at the upstream issue and the revert condition. Verified locally: the action's exact snippet on RF master crashes on Julia 1.12.6 and completes (162 invalidations, table printed) on 1.11.9. `julia-actions/julia-invalidations` has no input to skip/soften the report step, so a version pin is the only workaround that keeps the job informative; the action `Pkg.add`s SnoopCompile fresh each run, so reverting to `'1'` after an upstream fix restores latest-stable coverage with no other change.

Trade-off: the job measures 1.11 invalidations rather than latest-stable until upstream fixes #465 — versus today, where it measures nothing and every PR carries a spurious red check.

Not verified: the workflow run itself on CI (fires on this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
